### PR TITLE
feat: Add Asset Results View into search results screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/mobile/tradeverse/screens/explore-search-results/_components/result-cards/asset-result.jsx
+++ b/mobile/tradeverse/screens/explore-search-results/_components/result-cards/asset-result.jsx
@@ -1,0 +1,61 @@
+import { Text, View } from "react-native";
+import React from "react";
+import {
+  COLORS,
+  FONT_WEIGHTS,
+  SIZE_CONSTANT,
+  SIZES,
+} from "../../../../constants/theme";
+import ContentImage from "../../../../components/images/content-image";
+
+export default function AssetResult({ style, asset }) {
+  return (
+    <View
+      style={{
+        paddingHorizontal: SIZES.small,
+        paddingTop: SIZE_CONSTANT * 1.2,
+        paddingBottom: SIZE_CONSTANT * 1.4,
+        borderBottomWidth: 0.5,
+        borderBottomColor: "#E5E5E5",
+        display: "flex",
+        flexDirection: "row",
+        gap: SIZE_CONSTANT * 1.2,
+        alignItems: "center",
+      }}
+    >
+      <ContentImage
+        src={asset.image}
+        style={{
+          height: SIZE_CONSTANT * 2.4,
+          width: SIZE_CONSTANT * 2.4,
+          borderRadius: SIZE_CONSTANT * 1.2,
+          borderWidth: 0.5,
+          borderColor: "#E5E5E5",
+        }}
+      />
+      <View
+        style={{
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Text
+          style={{
+            fontSize: SIZES.medium,
+            fontWeight: FONT_WEIGHTS.semibold,
+          }}
+        >
+          {asset.abbreviation}
+        </Text>
+        <Text
+          style={{
+            color: COLORS.graytext,
+            fontSize: SIZES.xxSmall,
+          }}
+        >
+          {asset.label}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/mobile/tradeverse/screens/explore-search-results/index.jsx
+++ b/mobile/tradeverse/screens/explore-search-results/index.jsx
@@ -13,9 +13,10 @@ import SubForumsView from "./views/subforums-view";
 import TagsView from "./views/tags-view";
 import PostsView from "./views/posts-view";
 import UsersView from "./views/users-view";
+import AssetsView from "./views/asset-view";
 
 export default function ExploreRootScreen() {
-  const [selectedTab, setSelectedTab] = useState("assets");
+  const [selectedTab, setSelectedTab] = useState("popular");
 
   const { searchKey } = useLocalSearchParams();
 
@@ -56,11 +57,11 @@ export default function ExploreRootScreen() {
         </Pressable>
       </PaddedContainer>
         <Tabs selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
+
         {selectedTab === "popular" && (
           <PopularView data={SearchData.PopularData} />
         )}
-
-        {selectedTab === "assets" && (<></>)}
+        {selectedTab === "assets" && (<AssetsView data={SearchData.AssetsData} />)}
         {selectedTab === "tags" && (<TagsView data={SearchData.TagsData} />)}
         {selectedTab === "sub_forums" && (<SubForumsView data={SearchData.SubForumsData} />)}
         {selectedTab === "posts" && (<PostsView data={SearchData.PopularData} />)}

--- a/mobile/tradeverse/screens/explore-search-results/views/asset-view.jsx
+++ b/mobile/tradeverse/screens/explore-search-results/views/asset-view.jsx
@@ -1,0 +1,14 @@
+import { View, Text, ScrollView } from "react-native";
+import React from "react";
+import PostCard from "../_components/result-cards/post-result";
+import AssetResult from "../_components/result-cards/asset-result";
+
+export default function AssetsView({ data }) {
+  return (
+    <ScrollView>
+      {data.map((a, index) => (
+        <AssetResult key={index} asset={a} />
+      ))}
+    </ScrollView>
+  );
+}


### PR DESCRIPTION
## Overview

This pull request includes the addition of the assets view into the search result screen.

## Changes Made

### 1. **Asset Result Component**
- Created asset result component which will be showed to the user when assets tab is selected on the search results screen.

### 1. **View is created by the component mentioned above.**
- View is created by listing the asset result components.

