### PR TITLE
feat: Create Splash screen

### DIFF
--- a/mobile/tradeverse/app/_layout.jsx
+++ b/mobile/tradeverse/app/_layout.jsx
@@ -11,6 +11,7 @@ export default function RootLayout() {
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="auth" options={{ headerShown: false }} />
+        <Stack.Screen name="splash" options={{ headerShown: false }} />
       </Stack>
     </AuthProvider>
   );

--- a/mobile/tradeverse/app/splash.jsx
+++ b/mobile/tradeverse/app/splash.jsx
@@ -1,0 +1,7 @@
+import { View, Text } from "react-native";
+import React from "react";
+import WelcomingScreen from "../screens/welcoming";
+
+export default function SplashScreen() {
+  return <WelcomingScreen />;
+}

--- a/mobile/tradeverse/auth/context/auth-provider.jsx
+++ b/mobile/tradeverse/auth/context/auth-provider.jsx
@@ -11,9 +11,28 @@ export default function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [isLoggedin, setIsLoggedIn] = useState(false);
 
+  const [isTagSelected, setIsTagSelected] = useState(false);
+
   useEffect(() => {
     isAuthenticated();
   }, [isAuthenticated]);
+
+  useEffect(()=>{
+    console.log('====================================');
+    console.log('isTagSelected',isTagSelected);
+    console.log('====================================');
+    if(isAuthenticated){
+      if(isTagSelected){
+        router.replace('(tabs)');
+      }
+      else{
+        router.replace('splash');
+      }
+    }
+    else{
+      router.replace('auth');
+    }
+  },[isTagSelected,isAuthenticated]);
 
   const signIn = useCallback(async ({ username, password }) => {
     try {
@@ -22,9 +41,7 @@ export default function AuthProvider({ children }) {
       if (res.status === 200) {
         await AsyncStorage.setItem('authToken', res.data?.token);
         await AsyncStorage.setItem('username', username);
-        console.log('TRYING TO GET USER BY USERNAME');
         const userProfile = await getUserByUsername({ username });
-        console.log(userProfile);
         
         setUser(userProfile);
         setIsLoggedIn(true);
@@ -71,6 +88,7 @@ export default function AuthProvider({ children }) {
     setUser(null);
     router.replace('auth');
     await AsyncStorage.removeItem('authToken');
+    await AsyncStorage.removeItem('username');
     setLoading(false);
   }, []);
 
@@ -134,9 +152,11 @@ export default function AuthProvider({ children }) {
       isLoggedin,
       setLoading,
       signIn,
+      setIsTagSelected,
       loading,
       refetchUser,
       signUp,
+      isTagSelected,
       userProfile: user?.profile,
       isAuthenticated,
       logout,
@@ -149,6 +169,8 @@ export default function AuthProvider({ children }) {
       loading,
       signIn,
       refetchUser,
+      isTagSelected,
+      setIsTagSelected,
       signUp,
       logout,
       isAuthenticated

--- a/mobile/tradeverse/screens/welcoming/index.jsx
+++ b/mobile/tradeverse/screens/welcoming/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import {
   Text,
   StyleSheet,
@@ -16,11 +16,14 @@ import GlobalScreen from "../../components/ui/global-screen";
 import MainButton from "../../components/buttons/main-button";
 import ProfileImage from "../../components/images/profile-image";
 import { launchImageLibraryAsync } from "expo-image-picker";
+import { AuthContext } from "../../auth/context";
 
 export default function WelcomingScreen() {
   const [currentStep, setCurrentStep] = useState("profile"); // user_tag, profile
   const [selectedImage, setSelectedImage] = useState(null);
   const [selectedUserTag, setSelectedUserTag] = useState(null);
+
+  const { setIsTagSelected } = useContext(AuthContext);
 
   const openImageGallery = async () => {
     const result = await launchImageLibraryAsync({
@@ -35,6 +38,8 @@ export default function WelcomingScreen() {
     }
   };
 
+  
+
   const options = [
     { label: "Beginner", icon: "🏁", value: "beginner" },
     { label: "Day Trader", icon: "📊", value: "day_trader" },
@@ -46,6 +51,8 @@ export default function WelcomingScreen() {
   const handleNext = () => {
     if (currentStep === "profile") {
       setCurrentStep("user_tag");
+    } else {
+      setIsTagSelected(true);
     }
   };
 
@@ -117,7 +124,8 @@ export default function WelcomingScreen() {
           </TouchableOpacity>
           {selectedImage && (
             <MainButton
-            onPress={handleNext}
+
+              // onPress={handleNext}
               style={{ marginTop: SIZE_CONSTANT * 7 }}
               text="Continue"
             />
@@ -148,6 +156,7 @@ export default function WelcomingScreen() {
         ))}
 
         <MainButton
+          onPress={handleNext}
           style={{ marginTop: SIZE_CONSTANT * 2 }}
           text="Continue"
           disabled={!selectedUserTag}


### PR DESCRIPTION
## Overview

This pull request includes the creation of a splash screen that simulates user onboarding, appearing immediately after registration. It allows the user to choose a tag and optionally upload a profile photo.

## Changes Made

### **Added Components**
- **Splash Screen**
  - Created a `WelcomingScreen` that appears right after the user completes the registration process.
  - The screen asks the user to select a tag from a set of options.
  - It also includes functionality for the user to upload an optional profile photo.

### **Added Functions**
- **Tag Selection**
  - Added functionality for users to choose a preferred tag during the onboarding process.
  
- **Profile Photo Upload**
  - Implemented an optional profile photo upload feature, allowing users to add a profile picture after registration.

### **Screen Flow**
- **Registration to Splash Screen Transition**
  - The splash screen is shown right after successful registration to guide users through the onboarding process.

