### PR TITLE
Dropdown menu opening button no longer links to account page.

### DIFF
--- a/web/tradeverse/package-lock.json
+++ b/web/tradeverse/package-lock.json
@@ -5402,7 +5402,6 @@
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
       "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/web/tradeverse/src/components/structure/RenderNavigation.js
+++ b/web/tradeverse/src/components/structure/RenderNavigation.js
@@ -201,21 +201,23 @@ export const RenderMenu = () => {
           {user.isAuthenticated ? (
             <div className={styles.menuItem}>
               <div className={styles.userDropdown} onClick={toggleDropdown}>
-                <Link to="/account" className={styles.usernameLink}>
-                  <h5>{user.name}</h5>
-                </Link>
+                <h5>{user.name}</h5>
                 {isDropdownOpen && (
                   <div className={styles.dropdownContent}>
-                    <p
+                    <Link
+                      className={styles.clickableLink}
+                      to="/account"
                       style={{
                         color: "black",
                         fontWeight: "bold",
                         marginBottom: "5",
+                        display: "block",
                       }}
                     >
                       {user.name}
-                    </p>
+                    </Link>
                     <Link
+                      className={styles.clickableLink}
                       to={"#"}
                       onClick={logout}
                       style={{ color: "red", fontWeight: "lighter" }}

--- a/web/tradeverse/src/components/styles/style.module.css
+++ b/web/tradeverse/src/components/styles/style.module.css
@@ -239,12 +239,12 @@
   margin-left: 5px;
 }
 
-.usernameLink {
+.clickableLink {
   text-decoration: none;
   color: inherit; /* Matches current text color */
 }
 
-.usernameLink:hover {
+.clickableLink:hover {
   text-decoration: underline; /* Add underline on hover */
   color: #007bff; /* Optional: Change color on hover */
 }


### PR DESCRIPTION
Title. Also removed hover-underline on the dropdown menu opening button (visible as the users username on the home page right menu), and added hover-underline to the buttons on the dropdown menu, namely account page and logout. This hover-underline can be achieved by adding className={styles.clickableLink}. Closes #423 