### PR TITLE
Migrate profile photo storage to filesystem & move images to permanent storage

### DIFF
--- a/backend/src/main/java/com/bounswe2024group10/Tradeverse/service/AuthenticationService.java
+++ b/backend/src/main/java/com/bounswe2024group10/Tradeverse/service/AuthenticationService.java
@@ -1,5 +1,10 @@
 package com.bounswe2024group10.Tradeverse.service;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +42,19 @@ public class AuthenticationService {
         }
         if (userRepository.findByUsername(registerRequest.getUsername()) != null) {
             return new RegisterResponse(false, "Username is already in use", null, null);
+        }
+        if (registerRequest.getProfilePhoto() != null) {
+            try {
+                File file = new File("images/" + UUID.randomUUID() + ".jpg");
+                file.createNewFile();
+                FileOutputStream fos = new FileOutputStream(file);
+                fos.write(Base64.getDecoder().decode(registerRequest.getProfilePhoto()));
+                fos.close();
+                registerRequest.setProfilePhoto(file.getAbsolutePath());
+            } catch (IOException e) {
+                e.printStackTrace();
+                return new RegisterResponse(false, "Error while saving profile photo", null, null);
+            }
         }
         User user = new User(); 
         user.setEmail(registerRequest.getEmail());

--- a/backend/src/main/java/com/bounswe2024group10/Tradeverse/service/UserService.java
+++ b/backend/src/main/java/com/bounswe2024group10/Tradeverse/service/UserService.java
@@ -4,6 +4,13 @@ import com.bounswe2024group10.Tradeverse.dto.GetUserDetailsResponse;
 import com.bounswe2024group10.Tradeverse.dto.SetUserDetailsRequest;
 import com.bounswe2024group10.Tradeverse.model.User;
 import com.bounswe2024group10.Tradeverse.repository.UserRepository;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -30,7 +37,17 @@ public class UserService {
             user.setEmail(userDetailsRequest.getEmail());
         }
         if (userDetailsRequest.getProfilePhoto() != null) {
-            user.setProfilePhoto(userDetailsRequest.getProfilePhoto());
+            try {
+                File file = new File("images/" + UUID.randomUUID() + ".jpg");
+                file.createNewFile();
+                FileOutputStream fos = new FileOutputStream(file);
+                fos.write(Base64.getDecoder().decode(userDetailsRequest.getProfilePhoto()));
+                fos.close();
+                user.setProfilePhoto(file.getAbsolutePath());
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
         }
         if (userDetailsRequest.getBio() != null) {
             user.setBio(userDetailsRequest.getBio());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - images-data:/images
   web:
     build:
       context: ./web/tradeverse
@@ -38,3 +40,4 @@ services:
 
 volumes:
   db-data:
+  images-data:


### PR DESCRIPTION
- Now storing profile photos in filesystem, too.
- Storing all images in a new volume, images.
- All endpoints are still accepting Base64, so that nothing will change for front and mobile teams.
- Changed updateUserDetails and register to provide consistency.
- Save all photos in volume so that no image will be deleted.

<img width="1022" alt="Screenshot 2024-12-08 at 3 54 20 PM" src="https://github.com/user-attachments/assets/ea539cc3-c509-4aba-97b0-0d444694f08f">
